### PR TITLE
var doesn't declare variables in ruby =D

### DIFF
--- a/lib/geohex/v3/zone.rb
+++ b/lib/geohex/v3/zone.rb
@@ -334,7 +334,7 @@ module Geohex
           elsif y > x
             edge_x = x + dif_x
             edge_y = y - dif_y
-            var h_xy = edge_x
+            h_xy = edge_x
             edge_x = edge_y
             edge_y = h_xy
             x = edge_x - dif_x


### PR DESCRIPTION
maybe a holdover from transcription from javascript? the tests still pass so maybe there is no coverage of the `else` clause off `adjust_x_y`. found it by mistake when processing some corrupt data.

I think it can be reproduced it was blowing up for me on a code path with `nil` `x` values.

this will resolve the syntax issue, please advise on a testing strategy if required.

toshiwo/geohex-v3#13